### PR TITLE
Fix https://github.com/cathive/concourse-chartmuseum-resource/issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /src
 RUN npm -s install && npm -s run build && npm -s test && npm -s pack && mv cathive-concourse-chartmuseum-resource-*.tgz /data/cathive-concourse-chartmuseum-resource.tgz
 
 FROM node:9.5.0-alpine
-RUN apk add --no-cache gnupg
+RUN apk add --no-cache gnupg ca-certificates
 COPY --from=builder "/data/helm" "/usr/local/bin/helm"
 COPY --from=builder "/data/cathive-concourse-chartmuseum-resource.tgz" "/tmp/cathive-concourse-chartmuseum-resource.tgz"
 RUN npm -s install -g /tmp/cathive-concourse-chartmuseum-resource.tgz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,6 @@ RUN npm -s install -g /tmp/cathive-concourse-chartmuseum-resource.tgz \
 && ln -sf /usr/local/bin/concourse-chartmuseum-resource-in /opt/resource/in \
 && ln -sf /usr/local/bin/concourse-chartmuseum-resource-out /opt/resource/out
 ENV PATH="/usr/local/bin:/usr/bin:/bin"
+RUN helm init --client-only
 LABEL maintainer="headcr4sh@gmail.com" \
       version="0.3.0-pre"


### PR DESCRIPTION
Added `helm init --client-only` to `Dockerfile`