### PR TITLE
Use headers when fetching the chart

### DIFF
--- a/out.ts
+++ b/out.ts
@@ -257,10 +257,12 @@ export default async function out(): Promise<{ data: Object, cleanupCallback: ((
     process.stderr.write(`- Version: ${version}\n\n`);
 
     // Fetch Chart that has just been uploaded.
-    headers = createFetchHeaders(request); // We need new headers. (Content-Length should be "0" again...) 
+    headers = createFetchHeaders(request); // We need new headers. (Content-Length should be "0" again...)
     const chartInfoUrl = `${request.source.server_url}api/charts/${request.source.chart_name}/${version}`;
     process.stderr.write(`Fetching chart data from "${chartInfoUrl}"...\n`);
-    const chartResp = await fetch(`${request.source.server_url}api/charts/${request.source.chart_name}/${version}`);
+    const chartResp = await fetch(
+        `${request.source.server_url}api/charts/${request.source.chart_name}/${version}`,
+        { headers: headers });
     if (!chartResp.ok) {
         process.stderr.write("Download of chart information failed.\n")
         process.stderr.write((await chartResp.buffer()).toString());


### PR DESCRIPTION
Our put step was failing after uploading the chart. When trying to fetch the chart data after uploading we got this error message:

```
Processing chart at "/tmp/build/put/some-charts/charts/some-chart"...
	
Performing "helm package"...
	
Inspecting chart file: "/tmp/tmp-915nOqXa3lI2t/some-chart-0.3.0.tgz"...
	
Uploading chart file: "/tmp/tmp-915nOqXa3lI2t/some-chart-0.3.0.tgz"...
	
Helm Chart has been uploaded.
	
- Name: some-chart
	
- Version: 0.3.0
	

	
Fetching chart data from "https://some.chartrepo.io/api/charts/some-chart/0.3.0"...
	
Download of chart information failed.
	
{"error":"unauthorized"}
```

We are using basic auth and have disabled anon GET operations. Turns out the headers generated in out.ts before fetching the uploaded chart is not used by the fetch operation.