### PR TITLE
Support Harbor API (and bump to v0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2019-09-06
+
+### Added
+
+- Introduced the `harbor_api` param to the `out` resource for interacting with the (*quite different*) Harbor API (*although it uses chartmuseum in the backend*)
+  
 ## [0.7.0] - 2019-08-28
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Introduced the `harbor_api` param to the `out` resource for interacting with the (*quite different*) Harbor API (*although it uses chartmuseum in the backend*)
+- Introduced the `harbor_api` source value for interacting with the (*quite different*) Harbor API (*although it uses chartmuseum in the backend*)
   
 ## [0.7.0] - 2019-08-28
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN npm -s install -g /tmp/cathive-concourse-chartmuseum-resource.tgz \
 ENV PATH="/usr/local/bin:/usr/bin:/bin"
 RUN helm init --client-only
 LABEL maintainer="Benjamin P. Jung <headcr4sh@gmail.com>" \
-      version="0.7.0" \
+      version="0.7.1" \
       org.concourse-ci.target-version="5.4.1" \
       org.concourse-ci.resource-id="chartmuseum" \
       org.concourse-ci.resource-name="ChartMuseum package management" \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ resource_types:
 
 ## Source Configuration
 
-* `server_url`: *Required.* The address of the Chartmuseum instance. For chartmuseum, this'll be something like `https://chartmuseum.yourdomain.com/api/charts`. For harbor (which uses chartmuseum but changes the URL), this'll be something like `https://harbor.yourdomain.com/chartrepo` (for all charts) or `https://harbor.yourdomain.com/chartrepo/<project name>` for charts within a specific project.
+* `server_url`: *Required.* The address of the Chartmuseum/Harbor API. For chartmuseum, this'll be something like `https://chartmuseum.yourdomain.com/api/charts`. For harbor (*which uses chartmuseum but changes the API and path*), this'll be something like `https://harbor.yourdomain.com/api/chartrepo/charts` (*for the default "library" project*) or `https://harbor.yourdomain.com/api/chartrepo/<project name>/charts` for other projects.
 
 * `chart_name`: *Required* The name of the chart to operate upon.
 
@@ -37,6 +37,9 @@ resource_types:
 
 * `basic_auth_password`: Optional password to be used if your ChartMuseum is username/password protected.
   If provided, the paramter `basic_auth_username` must also be specified.
+
+* `harbor_api`: Optional, set to `true` use the Harbor API (*which is different enough to the standard ChartMuseum API not to work*) 
+
 
 ## Behavior
 
@@ -94,3 +97,4 @@ unless overwritten by the parameter `target_basename`.
 * `key_passphrase`: If `sign` has been set to `true` this parameter can be used to
   specifcy the passphrase that protects the GPG signing key to be used to sign
   the chart package.
+

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ resource_types:
 
 ## Source Configuration
 
-* `server_url`: *Required.* The address of the Chartmuseum instance. Must end with a slash.
+* `server_url`: *Required.* The address of the Chartmuseum instance. For chartmuseum, this'll be something like `https://chartmuseum.yourdomain.com/api/charts`. For harbor (which uses chartmuseum but changes the URL), this'll be something like `https://harbor.yourdomain.com/chartrepo` (for all charts) or `https://harbor.yourdomain.com/chartrepo/<project name>` for charts within a specific project.
 
 * `chart_name`: *Required* The name of the chart to operate upon.
 

--- a/check.ts
+++ b/check.ts
@@ -18,7 +18,7 @@ const stderr = process.stderr;
     const headers = createFetchHeaders(request);
 
     // Requests the charts from the remote endpoint.
-    let charts = await (await fetch(`${request.source.server_url}${request.source.chart_name}`, { headers: headers })).json() as any[];
+    let charts = await (await fetch(`${request.source.server_url}/${request.source.chart_name}`, { headers: headers })).json() as any[];
 
     // If a version has been specified in the check request, we'll use it to filter out all results
     // that are "smaller" by using semver's built-in comparison mechanism.

--- a/check.ts
+++ b/check.ts
@@ -18,7 +18,7 @@ const stderr = process.stderr;
     const headers = createFetchHeaders(request);
 
     // Requests the charts from the remote endpoint.
-    let charts = await (await fetch(`${request.source.server_url}api/charts/${request.source.chart_name}`, { headers: headers })).json() as any[];
+    let charts = await (await fetch(`${request.source.server_url}${request.source.chart_name}`, { headers: headers })).json() as any[];
 
     // If a version has been specified in the check request, we'll use it to filter out all results
     // that are "smaller" by using semver's built-in comparison mechanism.

--- a/in.ts
+++ b/in.ts
@@ -26,7 +26,7 @@ const writeFile = util.promisify(fs.writeFile);
     const headers = createFetchHeaders(request);
 
     // Fetch metadata
-    const chartResp = await fetch(`${request.source.server_url}api/charts/${request.source.chart_name}/${request.version.version}`, { headers: headers });
+    const chartResp = await fetch(`${request.source.server_url}/${request.source.chart_name}/${request.version.version}`, { headers: headers });
     const chartJson = await chartResp.json();
 
     // Read params and pre-initialize them with documented default values.

--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,7 @@ interface Request {
         version_range?: string
         basic_auth_username?: string
         basic_auth_password?: string
+        harbor_api?: boolean        
     }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -7,10 +7,6 @@ export async function retrieveRequestFromStdin<T extends any>(): Promise<T> {
         process.stdin.on("end", async () => {
             try {
                 const json = JSON.parse(inputRaw) as T;
-                if (!json.source.server_url.endsWith("/")) {
-                    // Forgive input errors and append missing slash if the user did not honor the docs.
-                    json.source.server_url = `${json.source.server_url}/`;
-                }
                 resolve(json);
             } catch (e) {
                 reject(e);

--- a/out.ts
+++ b/out.ts
@@ -222,7 +222,7 @@ export default async function out(): Promise<{ data: Object, cleanupCallback: ((
     const readStream = fs.createReadStream(chartFile);
     let postResult: Response;
     try {
-        let postUrl = `${request.source.server_url}api/charts`;
+        let postUrl = `${request.source.server_url}`;
         if (request.params.force) {
             postUrl += "?force=true"
         }
@@ -232,14 +232,14 @@ export default async function out(): Promise<{ data: Object, cleanupCallback: ((
             body: readStream
         });
     } catch (e) {
-        process.stderr.write("Upload of chart file has failed.\n");
+        process.stderr.write(`Upload of chart file to "${request.source.server_url}" has failed.\n`);
         process.stderr.write(e);
         process.exit(124);
         throw e; // Tricking the typescript compiler.
     }
 
     if (postResult.status != 201) {
-        process.stderr.write(`An error occured while uploading the chart: "${postResult.status} - ${postResult.statusText}".\n`);
+        process.stderr.write(`An error occured while uploading the chart to "${request.source.server_url}" : "${postResult.status} - ${postResult.statusText}".\n`);
         process.exit(postResult.status);
     }
 

--- a/out.ts
+++ b/out.ts
@@ -7,6 +7,7 @@ import * as path from "path";
 import * as util from "util";
 import * as semver from "semver";
 import * as rimraf from "rimraf";
+import * as FormData from "form-data";
 
 import fetch, { Body, Response } from "node-fetch";
 import * as tmp from "tmp";
@@ -215,11 +216,18 @@ export default async function out(): Promise<{ data: Object, cleanupCallback: ((
         process.exit(120);
     }
 
-    headers.append("Content-length", String(chartFileStat.size))
-    headers.append("Content-Disposition", `attachment; filename="${path.basename(chartFile)}"`)
+    //headers.append("Content-length", String(chartFileStat.size))
+    //headers.append("Content-Disposition", `attachment; filename="${path.basename(chartFile)}"`)
+    //headers.append("Content-Disposition", `form-data; name="chart"; filename="${path.basename(chartFile)}"`)
+    //headers.append("Content-Type","application/gzip")
 
     process.stderr.write(`Uploading chart file: "${chartFile}"...\n`);
-    const readStream = fs.createReadStream(chartFile);
+    // const readStream = fs.createReadStream(chartFile);
+
+    // Update for multipart uploads required by harbor API
+    var form = new FormData();
+    form.append('chart', fs.createReadStream(chartFile));
+
     let postResult: Response;
     try {
         let postUrl = `${request.source.server_url}`;
@@ -229,7 +237,7 @@ export default async function out(): Promise<{ data: Object, cleanupCallback: ((
         postResult = await fetch(postUrl, {
             method: "POST",
             headers: headers,
-            body: readStream
+            body: form
         });
     } catch (e) {
         process.stderr.write(`Upload of chart file to "${request.source.server_url}" has failed.\n`);
@@ -258,10 +266,10 @@ export default async function out(): Promise<{ data: Object, cleanupCallback: ((
 
     // Fetch Chart that has just been uploaded.
     headers = createFetchHeaders(request); // We need new headers. (Content-Length should be "0" again...)
-    const chartInfoUrl = `${request.source.server_url}${request.source.chart_name}/${version}`;
+    const chartInfoUrl = `${request.source.server_url}/${request.source.chart_name}/${version}`;
     process.stderr.write(`Fetching chart data from "${chartInfoUrl}"...\n`);
     const chartResp = await fetch(
-        `${request.source.server_url}${request.source.chart_name}/${version}`,
+        `${request.source.server_url}/${request.source.chart_name}/${version}`,
         { headers: headers });
     if (!chartResp.ok) {
         process.stderr.write("Download of chart information failed.\n")
@@ -270,22 +278,20 @@ export default async function out(): Promise<{ data: Object, cleanupCallback: ((
     }
     const chartJson = await chartResp.json();
 
-    if (version != chartJson.version) {
-        process.stderr.write(`Version mismatch in uploaded Helm Chart. Got: ${chartJson.version}, expected: ${version}.\n`);
+    if (version != chartJson.metadata.version) {
+        process.stderr.write(`Version mismatch in uploaded Helm Chart. Got: ${chartJson.metadata.version}, expected: ${version}.\n`);
         process.exit(203);
     }
 
     const response: OutResponse = {
         version: {
-            version: chartJson.version,
-            digest: chartJson.digest
+            version: chartJson.metadata.version,
+            digest: chartJson.metadata.digest
         },
         metadata: [
-            { name: "created", value: chartJson.created },
-            { name: "description", value: chartJson.description },
-            { name: "appVersion", value: chartJson.appVersion },
-            { name: "home", value: chartJson.home },
-            { name: "tillerVersion", value: chartJson.tillerVersion },
+            { name: "created", value: chartJson.metadata.created },
+            { name: "description", value: chartJson.metadata.description },
+            { name: "appVersion", value: chartJson.appVersion }
         ]
     };
 

--- a/out.ts
+++ b/out.ts
@@ -258,10 +258,10 @@ export default async function out(): Promise<{ data: Object, cleanupCallback: ((
 
     // Fetch Chart that has just been uploaded.
     headers = createFetchHeaders(request); // We need new headers. (Content-Length should be "0" again...)
-    const chartInfoUrl = `${request.source.server_url}api/charts/${request.source.chart_name}/${version}`;
+    const chartInfoUrl = `${request.source.server_url}${request.source.chart_name}/${version}`;
     process.stderr.write(`Fetching chart data from "${chartInfoUrl}"...\n`);
     const chartResp = await fetch(
-        `${request.source.server_url}api/charts/${request.source.chart_name}/${version}`,
+        `${request.source.server_url}${request.source.chart_name}/${version}`,
         { headers: headers });
     if (!chartResp.ok) {
         process.stderr.write("Download of chart information failed.\n")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@cathive/concourse-chartmuseum-resource",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "rimraf": "^3.0.0",
         "semver": "^6.3.0",
         "tmp": "^0.1.0",
-        "yamljs": "^0.3.0"
+        "yamljs": "^0.3.0",
+        "form-data": "^2.5.1"        
     },
     "devDependencies": {
         "@types/node": "^12.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@cathive/concourse-chartmuseum-resource",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "main": "./index.js",
     "dependencies": {
         "node-fetch": "^2.6.0",


### PR DESCRIPTION
Hey - I spent some time after getting stuck on issue #8 digging into the differences between the ChartMuseum API and the Harbor API. This PR adds an optional `harbor_api` value to the source, which plays nicer with Harbor. If the value isn't added, nothing changes, and the resource would still (I expect) work with ChartMuseum.

It's working nicely with my Harbor install, but I haven't validated it against ChartMuseum.

Cheers!
D