### PR TITLE
Adjusts server_url for fetching charts

### DIFF
--- a/in.ts
+++ b/in.ts
@@ -29,7 +29,7 @@ const writeFile = util.promisify(fs.writeFile);
     const chartResp = await fetch(`${request.source.server_url}/${request.source.chart_name}/${request.version.version}`, { headers: headers });
     const chartJson = await chartResp.json();
 
-    if (request.source.harbor_api === true) {    
+    if (request.source.harbor_api === true) {
         // Read params and pre-initialize them with documented default values.
         let targetBasename: string = `${chartJson.metadata.name}-${chartJson.metadata.version}`;
         if (request.params != null) {
@@ -49,10 +49,12 @@ const writeFile = util.promisify(fs.writeFile);
             ]
         }
 
-        const tgzResp = await fetch(`${request.source.server_url}charts/${request.source.chart_name}-${chartJson.metadata.version}.tgz`, { headers: headers });
+        var non_api_server_url = request.source.server_url.replace("api/","")
+
+        const tgzResp = await fetch(`${non_api_server_url}/${request.source.chart_name}-${chartJson.metadata.version}.tgz`, { headers: headers });
         await writeFile(path.resolve(destination, `${targetBasename}.tgz`), await tgzResp.buffer());
 
-        const provResp = await fetch(`${request.source.server_url}charts/${request.source.chart_name}-${chartJson.metadata.version}.tgz.prov`, { headers: headers });
+        const provResp = await fetch(`${non_api_server_url}/${request.source.chart_name}-${chartJson.metadata.version}.tgz.prov`, { headers: headers });
         await writeFile(path.resolve(destination, `${targetBasename}.tgz.prov`), await provResp.buffer());
 
         await writeFile(path.resolve(destination, `${targetBasename}.json`), JSON.stringify(chartJson));
@@ -80,14 +82,16 @@ const writeFile = util.promisify(fs.writeFile);
             ]
         }
 
-        const tgzResp = await fetch(`${request.source.server_url}charts/${request.source.chart_name}-${chartJson.version}.tgz`, { headers: headers });
+        var non_api_server_url = request.source.server_url.replace("api/","")
+
+        const tgzResp = await fetch(`${non_api_server_url}/${request.source.chart_name}-${chartJson.version}.tgz`, { headers: headers });
         await writeFile(path.resolve(destination, `${targetBasename}.tgz`), await tgzResp.buffer());
 
-        const provResp = await fetch(`${request.source.server_url}charts/${request.source.chart_name}-${chartJson.version}.tgz.prov`, { headers: headers });
+        const provResp = await fetch(`${non_api_server_url}/${request.source.chart_name}-${chartJson.version}.tgz.prov`, { headers: headers });
         await writeFile(path.resolve(destination, `${targetBasename}.tgz.prov`), await provResp.buffer());
 
         await writeFile(path.resolve(destination, `${targetBasename}.json`), JSON.stringify(chartJson));
-        process.stdout.write(JSON.stringify(response, null, 2));        
+        process.stdout.write(JSON.stringify(response, null, 2));
     }
 
 })();


### PR DESCRIPTION
Currently pulling a tgz in from a normal chartmuseum produces an empty
tarball.

This is a terrible "fix", but it seems that server_url cannot be a base
url because of the differences in path between Harbor and normal
Chartmuseum, we need the user to tell us about the full path to the api.

Harbor apparently decided that to change functionality between metadata
and modification/fetching we need to modify this url not in some sane
way, like entirely on the right side of the path after the endpoint, but
on two different paths, ie:
/api/somenoise/charts and /somenoise/charts.

https://github.com/helm/chartmuseum/blob/b58d67830e793bac2a345aade98c36a7825104fa/README.md#api