### PR TITLE
Adds retries to immediate fetch after putting chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -264,6 +264,11 @@
                 }
             }
         },
+        "ts-retry-promise": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/ts-retry-promise/-/ts-retry-promise-0.3.1.tgz",
+            "integrity": "sha512-7ve0vb1WcKvSkUexv9PQmE1++TL/My2vLZgh2zeO0uRLuMKRE4Rk909HwOOYUYaI47SEABl6L31cDb7s5eXabw=="
+        },
         "typescript": {
             "version": "3.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
     "version": "0.9.0",
     "main": "./index.js",
     "dependencies": {
+        "form-data": "^3.0.0",
         "node-fetch": "^2.6.0",
         "rimraf": "^3.0.2",
         "semver": "^7.1.3",
         "tmp": "^0.1.0",
-        "yamljs": "^0.3.0",
-        "form-data": "^3.0.0"
+        "ts-retry-promise": "^0.3.1",
+        "yamljs": "^0.3.0"
     },
     "devDependencies": {
         "@types/node": "^13.9.0",


### PR DESCRIPTION
chartmuseum does not seem to have read-after-write consistency,
so we are seeing failures of the immediate fetch after pushing a new
chart. Maybe by retrying it (should have a delay?) this can be fixed.

https://github.com/helm/chartmuseum/issues/323

I have no idea if this works, I've never used javascript before. Package seems to ship with a default 100ms delay per retry.